### PR TITLE
Add matplotsoccer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,13 +195,16 @@ There are lots of different ways to install both `Python` and all these differen
 ##### Resources:
 
 - [`socceraction`](https://github.com/ML-KULeuven/socceraction)
-  > Python library for valuing the individual actions performed by soccer players. Includes an Expected Threat (xT) implementation. From [Tom Decroos](https://twitter.com/TomDecroos) et. al.
+  > A python library for valuing the individual actions performed by soccer players. Includes an Expected Threat (xT) implementation. From [Tom Decroos](https://twitter.com/TomDecroos) et. al.
 
 - [`statsbombpy`](https://github.com/statsbomb/statsbombpy)
   > A python library written by Francisco Goitia to access StatsBomb data.
 
+- [`matplotsoccer`](https://github.com/TomDecroos/matplotsoccer)
+  > A python library for visualising soccer event data. Also by [Tom Decroos](https://twitter.com/TomDecroos).
+
 - [`ggsoccer`](https://github.com/Torvaney/ggsoccer)
-  > Not `Python`, but this soccer visualization library from [Ben Torvaney](https://twitter.com/Torvaney) is great. Could someone write a `Python` one, please?
+  > Not `Python`, but this soccer visualization library from [Ben Torvaney](https://twitter.com/Torvaney) is great.
 
 - [Python Data Science Handbook](https://github.com/jakevdp/PythonDataScienceHandbook)
   > [Jake VanderPlas](https://twitter.com/jakevdp) made his entire Python Data Science Handbook and accompanying Jupyter notebooks available online. It's a tremendous resource.


### PR DESCRIPTION
I came across Matplotsoccer the other day & it looks like a good python equivalent to ggsoccer. 

Some notes:

* I haven't used the library much/at all myself (yet), so if you want a stronger endorsement before adding it to the handbook, that's fine with me.
* I put it next to ggsoccer in the list, since it serves the same role, but as another Tom Decroos library, maybe it should go after socceraction. What do you think?
* Likewise, if the presence of a python plotting library means you think ggsoccer should be removed from the readme, that would make sense to me; everything else is python and it would help reduce the potential for confusion for newcomers.