### PR TITLE
Added sep argument to json_normalize

### DIFF
--- a/notebooks/database_population_and_querying.ipynb
+++ b/notebooks/database_population_and_querying.ipynb
@@ -68,7 +68,7 @@
     "        for e in requests.get(url=match_url.format(match_id)).json():\n",
     "            events.append(e)\n",
     "        \n",
-    "    return pd.json_normalize(events)"
+    "    return pd.json_normalize(events, sep='_')"
    ]
   },
   {
@@ -100,29 +100,6 @@
     "competition_id = 43\n",
     "season_id = 3\n",
     "df = parse_data(competition_id, season_id)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "columns = {k: k.replace(\".\", \"_\") for k in df.columns}\n",
-    "df = df.rename(columns=columns)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The `pd.json_normalize` function uses dot notation to represent different levels of hierarchy.\n",
-    "\n",
-    "This is generally fine, except periods cannot be used in SQL column names.\n",
-    "\n",
-    "We use a dictionary comprehension to generate a list of old and new column names, and use `df.rename` to apply those changes.\n",
-    "\n",
-    "---"
    ]
   },
   {


### PR DESCRIPTION
`json_normalize` now takes a `sep` argument so that can save the dictionary comprehension to replace the periods with underscores in the column names