### PR TITLE
Add encoding to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 from distutils.core import setup
 
+# Encoding error fix on Windows: https://stackoverflow.com/questions/49640513/unicodedecodeerror-charmap-codec-cant-decode-byte-0x9d-in-position-x-charac
 setup(
     name='AnalyticsHandbook',
     version='0.2dev',
     packages=['soccerutils', ],
     license='Creative Commons Attribution-Noncommercial-Share Alike license',
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding='utf8').read(),
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from distutils.core import setup
 
-# Encoding error fix on Windows: https://stackoverflow.com/questions/49640513/unicodedecodeerror-charmap-codec-cant-decode-byte-0x9d-in-position-x-charac
 setup(
     name='AnalyticsHandbook',
     version='0.2dev',


### PR DESCRIPTION
Windows users may have issue when trying to install in a non-Colab environment if UTF-8 is not specified. See https://stackoverflow.com/questions/49640513/unicodedecodeerror-charmap-codec-cant-decode-byte-0x9d-in-position-x-charac